### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/videos/the-search.md
+++ b/videos/the-search.md
@@ -19,4 +19,4 @@ Video could potentially prove that they're not present on a mismatched version.
   Second person on Skype.
 
 ## Anomalies
-* The version they are playing on is a lost version *(the original .jar file is lost, [read more here](https://minecraft.fandom.com/wiki/Java_Edition_Alpha_v1.0.17))*.
+* The version they are playing on is a lost version *(the original .jar file is lost, [read more here](https://minecraft.wiki/w/Java_Edition_Alpha_v1.0.17))*.


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.